### PR TITLE
Updated code of conduct for PythonNW specific reqs

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -4,34 +4,28 @@ title: Code of Conduct
 permalink: /code-of-conduct/
 ---
 
-# Code of Conduct
+_This code of conduct is based upon [https://www.python.org/psf/conduct/](https://www.python.org/psf/conduct/)_
 
-See [https://www.python.org/psf/conduct/](https://www.python.org/psf/conduct/)
+The Python North West community is made up of members with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences great successes and continued growth. When you're working with members of the community, this Code of Conduct will help steer your interactions and keep Python North West a positive, successful, and growing community.
 
-The Python NW community is made up of members with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences great successes and continued growth. When you're working with members of the community,
-this Code of Conduct will help steer your interactions and keep Python NW a positive, successful, and growing community.
+## Our Community 
 
-## Our Community
-
-Members of the Python NW community are **open, considerate, and respectful**. Behaviours that reinforce these values contribute to a positive environment, and include:
+Members of the Python North West community are **open, considerate, and respectful**. Behaviours that reinforce these values contribute to a positive environment, and include:
 
 - **Being open.** Members of the community are open to collaboration, whether it's on talks, patches, problems, or otherwise.
 - **Focusing on what is best for the community.** We're respectful of the processes set forth in the community, and we work within them.
 - **Acknowledging time and effort.** We're respectful of
-the volunteer efforts that permeate the Python NW community. We're thoughtful when addressing the efforts of others, keeping in mind that often times the labour was completed simply for the good of the
-community.
-- **Being respectful of differing viewpoints and experiences.** We're receptive to constructive comments and criticism, as the experiences and skill sets of other members contribute to the whole of
-our efforts.
+the volunteer efforts that permeate the Python North West community. We're thoughtful when addressing the efforts of others, keeping in mind that often times the labour was completed simply for the good of the community.
+- **Being respectful of differing viewpoints and experiences.** We're receptive to constructive comments and criticism, as the experiences and skill sets of other members contribute to the whole of our efforts.
 - **Showing empathy towards other community members.** We're attentive in our communications, whether in person or online, and we're tactful when approaching differing views.
 - **Being considerate.** Members of the community are considerate of their peers -- other Python users.
 - **Being respectful.** We're respectful of others, their positions, their skills, their commitments, and their efforts.
 - **Gracefully accepting constructive criticism.** When we disagree, we are courteous in raising our issues.
-- **Using welcoming and inclusive language.** We're
-accepting of all who wish to take part in our activities, fostering an environment where anyone can participate and everyone can make a difference.
+- **Using welcoming and inclusive language.** We're accepting of all who wish to take part in our activities, fostering an environment where anyone can participate and everyone can make a difference.
 
 ## Our Standards
 
-Every member of our community has the right to have their identity respected. The Python NW community is dedicated to providing a positive experience for everyone, regardless of age, gender identity and expression, sexual orientation, disability, physical appearance, body size, ethnicity,  nationality, race, or religion (or lack thereof), education, or socio-economic status.
+Every member of our community has the right to have their identity respected. The Python North West community is dedicated to providing a positive experience for everyone, regardless of age, gender identity and expression, sexual orientation, disability, physical appearance, body size, ethnicity,  nationality, race, or religion (or lack thereof), education, or socio-economic status.
 
 ### Inappropriate Behavior
 
@@ -58,19 +52,19 @@ Community members asked to stop any inappropriate behavior are expected to compl
 
 ### Consequences
 
-If a participant engages in behaviour that violates this code of conduct, the Python NW community Code of Conduct team may take any action they deem appropriate, including warning the offender or expulsion from the community and community events with no refund of event tickets. The full list of consequences for inappropriate behaviour is listed in the [Enforcement Procedures](https://www.python.org/psf/conduct/enforcement). Thank you for helping make this a welcoming, friendly community for everyone.
+If a participant engages in behaviour that violates this code of conduct, the Python North West  Code of Conduct organising team may take any action they deem appropriate, including warning the offender or expulsion from the community and community events with no refund of event tickets. Thank you for helping make this a welcoming, friendly community for everyone.
 
 ## Scope
 
-### Python NW Events
+### Python North West Events
 
-This Code of Conduct applies to the following people at events hosted by the Python NW meetup group:
+This Code of Conduct applies to the following people at events hosted by the Python North West meetup group:
 
-- Python NW organising committee
+- Python North West organising committee
 - speakers
 - panelists
 - tutorial or workshop leaders
-- organizers
+- organisers
 - volunteers
 - all attendees
 
@@ -79,35 +73,22 @@ The Code of Conduct applies in official venue event spaces, including:
 - walkways, hallways, elevators, and stairs that connect any of the above spaces
 - any associated socials that take place post- or pre- events
 
-The Code of Conduct applies to interactions with official event accounts on social media spaces and phone applications, including:
+The Code of Conduct applies to interactions with official event accounts on social media spaces and phone applications.
 
-- comments made on official conference phone apps
-- comments made on event video hosting services
-- comments made on the official event hashtag or panel hashtags
+Event organizers will enforce this code throughout the event and provide contact information for attendees.
 
-Event organizers will enforce this code throughout the event. Each event is required to provide a Code of Conduct committee that receives, evaluates, and acts on incident reports. Each event is required to provide contact information for the committee to attendees. The event
-Code of Conduct committee may (but is not required to) ask for advice from the Python Software Foundation Code of Conduct work group. The
-Python Software Foundation Code of Conduct work group can be reached by
-emailing [conduct-wg@python.org](mailto:conduct-wg@python.org).
+## Procedure for Handling Incidents 
 
-The Python Software Foundation Code of Conduct work group will
-receive and evaluate incident reports from the online communities listed above. The Python Software Foundation Code of Conduct work group will
-work with online community administrators/moderators to suggest actions
-to take in response to a report. In cases where the
-administrators/moderators disagree on the suggested resolution for a
-report, the Python Software Foundation Code of Conduct work group may
-choose to notify the Python Software Foundation board.
-
-### Contact Information
-
-If you believe that someone is violating the code of conduct, or have any other concerns, please contact a member of the Python NW organising team as soon as possible. They can be reached
-by emailing !!!!!!!!!!!!!!!!!!!!
-
-## Procedure for Handling Incidents
+Where applicable we will follow the Python Software Foundation procudures for
+reporting and enforcing incidents.
 
 [Community Member Procedure For Reporting Code of Conduct Incidents](https://www.python.org/psf/conduct/reporting)
 
 [Python Software Foundation Code of Conduct Working Group Enforcement Procedures](https://www.python.org/psf/conduct/enforcement)
+
+## Contact Information 
+
+If you believe that someone is violating the code of conduct, or have any other concerns, please contact a member of the Python North West organising team as soon as possible. They can be reached by emailing pythonnw@gmail.com or by contacting @pythonnw on Twitter.
 
 ## License
 


### PR DESCRIPTION
The code of conduct is taken from the PSF, which is a large, American
organisation. As such, much of it doesn't make sense for our group. I've
simplified it and ensured the relevant contact information is present.

Please have a read through the changes and let me know if you want me to make any alterations.